### PR TITLE
[BUG] Icon in taskbar

### DIFF
--- a/pytia_property_manager/material_manager/__init__.py
+++ b/pytia_property_manager/material_manager/__init__.py
@@ -49,6 +49,7 @@ class MaterialManager(Toplevel):
 
         self.title("Material Manager")
         self.attributes("-topmost", True)
+        self.attributes("-toolwindow", True)
         self.resizable(False, False)
         self.configure(cursor="wait")
         self.default_font = font.nametofont("TkDefaultFont")


### PR DESCRIPTION
Fixes #8 (Material manager shows taskbar icon): Material manager is now opened as toolwindow.
